### PR TITLE
Set subject before video conference is joined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,10 +23,11 @@ const Jutsu = (props) => {
 
   useEffect(() => {
     if (jitsi) {
+      jitsi.executeCommand('subject', subject)
       jitsi.addEventListener('videoConferenceJoined', () => {
         if (password) jitsi.executeCommand('password', password)
         jitsi.executeCommand('displayName', displayName)
-        jitsi.executeCommand('subject', subject)
+
       })
       setLoading(false)
     }


### PR DESCRIPTION
The subject of the video conference needs to be set before the conference is joined otherwise it is ignored and the default room name is shown.