### PR TITLE
Moved location of `setLoading(false)`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,9 +26,9 @@ const Jutsu = (props) => {
       jitsi.executeCommand('subject', subject)
       jitsi.addEventListener('videoConferenceJoined', () => {
         if (password) jitsi.executeCommand('password', password)
+        setLoading(false)
         jitsi.executeCommand('displayName', displayName)
       })
-      setLoading(false)
     }
     return () => jitsi && jitsi.dispose()
   }, [jitsi])


### PR DESCRIPTION
Moved location of `setLoading(false)` to inside of the videoConferenceJoined event listener.  If loading is set to false before the conference is joined, the loading component will only flash for a split second and then there will be a blank screen until the conference is joined.  This way, the loading component will be shown until the conference is ready to go.