### PR TITLE
Add password required event listener

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,13 +23,22 @@ const Jutsu = (props) => {
 
   useEffect(() => {
     if (jitsi) {
-      jitsi.executeCommand('subject', subject)
-      jitsi.addEventListener('videoConferenceJoined', () => {
-        if (password) jitsi.executeCommand('password', password)
-        jitsi.executeCommand('displayName', displayName)
-      })
-      setLoading(false)
+      jitsi.executeCommand("subject", subject);
+
+      jitsi.addEventListener("videoConferenceJoined", () => {
+        if (password) jitsi.executeCommand("password", password);
+        setLoading(false);
+        jitsi.executeCommand("displayName", displayName);
+      });
+
+      jitsi.addEventListener("passwordRequired", () => {
+        if (password) {
+          jitsi.executeCommand("password", password);
+        }
+        setLoading(false);
+      });
     }
+
     return () => jitsi && jitsi.dispose()
   }, [jitsi])
 


### PR DESCRIPTION
If a password (prop) is set when creating a room, the password is set in the videoConferenceJoined event listener.  If someone is joining a room that requires a password, it's either entered automatically (if the password prop was set) or the setLoading(false) in the passwordRequired event listener will allow them to see the "enter password" UI prompt.