### PR TITLE
expose all JitsiMeetExternalAPI options to <Jutsu />

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ export default App
 ## Supported Configuration
 > Check the [Jitsi Meet API docs](https://github.com/jitsi/jitsi-meet/blob/master/doc/api.md#api--new-jitsimeetexternalapidomain-options) for full configuration and how to use api commands when using the `useJitsi` hook
 
+### Options
+The `options` passed to `JitsiMeetExternalAPI`.
+>Properties specified in `options` will overwrite the configuration other configurations.
+
 ### Room Name
 The meeting room name
 >This prop is required to start a meeting

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types'
 import useJitsi from './useJitsi'
 
 const Jutsu = (props) => {
-  const { domain, roomName, displayName, password, jwt = null, subject } = props
+  const { domain, roomName, displayName, password, jwt = null, subject, options = {} } = props
   const { loadingComponent, containerStyles, jitsiContainerStyles, onMeetingEnd } = props
 
   const [loading, setLoading] = useState(true)
-  const jitsi = useJitsi({ roomName, parentNode: 'jitsi-container', jwt: jwt }, domain)
+  const jitsi = useJitsi({ roomName, parentNode: 'jitsi-container', jwt: jwt, ...options }, domain)
 
   const containerStyle = {
     width: '800px',
@@ -54,6 +54,7 @@ const Jutsu = (props) => {
 }
 
 Jutsu.propTypes = {
+  options: PropTypes.object,
   jwt: PropTypes.string,
   domain: PropTypes.string,
   subject: PropTypes.string,


### PR DESCRIPTION
Why? Because I find it cleaner code to use `<Jutsu />` as compared to `useJitsi`. But I also need more customization, such as `interfaceConfigOverwrite`. 