### PR TITLE
Add dependencies to hook

### DIFF
--- a/src/useJitsi.js
+++ b/src/useJitsi.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
-const useJitsi = (options, domain = 'meet.jit.si') => {
+const useJitsi = (options, domain = 'meet.jit.si', dependencies = []) => {
   const [jitsi, setJitsi] = useState(null)
 
   useEffect(() => {
@@ -13,7 +13,7 @@ const useJitsi = (options, domain = 'meet.jit.si') => {
       setJitsi({ error: 'JitsiMeetExternalAPI is not available, check if https://meet.jit.si/external_api.js was loaded' })
     }
     return () => jitsi && jitsi.dispose()
-  }, [])
+  }, dependencies)
 
   return jitsi
 }

--- a/src/useJitsi.js
+++ b/src/useJitsi.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
-const useJitsi = (options, domain = 'meet.jit.si', dependencies = []) => {
+const useJitsi = (options, domain = 'meet.jit.si') => {
   const [jitsi, setJitsi] = useState(null)
 
   useEffect(() => {
@@ -9,11 +9,10 @@ const useJitsi = (options, domain = 'meet.jit.si', dependencies = []) => {
       options.parentNode = document.getElementById(options.parentNode)
       // eslint-disable-next-line no-undef
       setJitsi(new JitsiMeetExternalAPI(domain, options))
-    } else {
-      setJitsi({ error: 'JitsiMeetExternalAPI is not available, check if https://meet.jit.si/external_api.js was loaded' })
+      return () => jitsi.dispose()
     }
-    return () => jitsi && jitsi.dispose()
-  }, dependencies)
+    setJitsi({ error: 'JitsiMeetExternalAPI is not available, check if https://meet.jit.si/external_api.js was loaded' })
+  }, [window.JitsiMeetExternalAPI])
 
   return jitsi
 }


### PR DESCRIPTION
First of all, thank you for this hook/component which made my first jitsi integration easy.

I try to avoid loading external script when not needed, so I have a hook to load those scripts when the displayed components need them.
Unfortunately, it does not work very well with `useJitsi` because it tries to create jitsi instance only once and never retry [due to the empty "dependencies" array on `useEffect` in src/useJitsi.js](https://github.com/this-fifo/jutsu/blob/master/src/useJitsi.js#L16)

I was able to make it work locally by passing dependencies as a third argument of `useJitsi` so it retries when the lib is loaded (in my case).

Here is what it looks like in my component:
```js
// load script
const loaded = useExternalScript('https://meet.jit.si/external_api.js');

// try to create jitsy instance and retry if `loaded` changes
const jitsi = useJitsi({roomName, parentNode}, undefined, [loaded]);

```

I made this PR whit that solution but maybe there is a better way to handle this?