### PR TITLE
Avoid null exception when transitioning to other component

### DIFF
--- a/src/useJitsi.js
+++ b/src/useJitsi.js
@@ -43,7 +43,7 @@ const useJitsi = ({
     })
     onMeetingEnd && client.addEventListener('readyToClose', onMeetingEnd)
 
-    return () => jitsi.dispose()
+    return () => jitsi && jitsi.dispose()
   }, [window.JitsiMeetExternalAPI])
 
   return {jitsi, error, loading}


### PR DESCRIPTION
A `cannot call dispose method of null` exception is being raised if you navigate to another components