### PR TITLE
Avoid failed to lock the conference problem

### DIFF
--- a/src/useJitsi.js
+++ b/src/useJitsi.js
@@ -37,11 +37,11 @@ const useJitsi = ({
       displayName && client.executeCommand('displayName', displayName)
     })
 
-    client.addEventListener('participantRoleChanged', function(event) {
-      if (password && event.role === "moderator") {
-        client.executeCommand('password', password);
+    client.addEventListener('participantRoleChanged', function (event) {
+      if (password && event.role === 'moderator') {
+        client.executeCommand('password', password)
       }
-    });
+    })
 
     client.addEventListener('passwordRequired', () => {
       password && client.executeCommand('password', password)

--- a/src/useJitsi.js
+++ b/src/useJitsi.js
@@ -34,9 +34,14 @@ const useJitsi = ({
     subject && client.executeCommand('subject', subject)
 
     client.addEventListener('videoConferenceJoined', () => {
-      password && client.executeCommand('password', password)
       displayName && client.executeCommand('displayName', displayName)
     })
+
+    client.addEventListener('participantRoleChanged', function(event) {
+      if (password && event.role === "moderator") {
+        client.executeCommand('password', password);
+      }
+    });
 
     client.addEventListener('passwordRequired', () => {
       password && client.executeCommand('password', password)


### PR DESCRIPTION
Avoid the `failed to lock the conference` when using self-hosted Jitis.
based on :
[IFrame API](https://jitsi.github.io/handbook/docs/dev-guide/dev-guide-iframe/)